### PR TITLE
Add execution confirmation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,19 @@
           "type": "boolean",
           "default": true,
           "description": "Allow active terminal running a SSH session as target for commands"
+        },
+        "markdown-execute.confirmation": {
+          "name": "Confirmation",
+          "type": "string",
+          "default": "pick",
+          "enum": ["none", "pick", "message", "modal"],
+          "enumDescriptions": [
+            "None: no confirmation before executing code block.",
+            "Pick: showQuickPick with options.",
+            "Message: showInformationMessage with buttons",
+            "Modal: modal showInformationMessage with buttons."
+          ],
+          "description": "Choose how confirmation is presented before executing code block."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,38 @@ export async function activate(context: vscode.ExtensionContext) {
           );
           return;
         }
+        const config = vscode.workspace.getConfiguration('markdown-execute');
+        const confirmation = config.get<string>('confirmation', 'none');
+        if (confirmation !== 'none') {
+          let confirmed = false;
+          if (confirmation === 'pick') {
+            const confirm = await vscode.window.showQuickPick(['Execute', 'Cancel'], {
+              placeHolder: 'Execute this code block in the terminal?',
+              ignoreFocusOut: true
+            });
+            confirmed = confirm === 'Execute';
+          }
+          else if (confirmation === 'message') {
+            const confirm = await vscode.window.showInformationMessage(
+              'Execute this code block in the terminal?',
+              'Execute',
+              'Cancel'
+            );
+            confirmed = confirm === 'Execute';
+          } else if (confirmation === 'modal') {
+            const confirm = await vscode.window.showInformationMessage(
+              'Execute this code block in the terminal?',
+              { modal: true },
+              'Execute',
+              'Cancel'
+            );
+            confirmed = confirm === 'Execute';
+          }
+          if (!confirmed) {
+            vscode.window.showInformationMessage('Execution cancelled.');
+            return;
+          }
+        }
         executeAt(args.runtime, args.command);
       }
     )


### PR DESCRIPTION
Hi @HansKre. 
You've created a a great extension. But many times I've accidentally pressed and executed a script from my `.md` files. I thought it would be great to have the option to confirm script execution by explicitly accepting or rejecting it.

Please take a look at it and let me know what you think. If you like the idea, please accept the changes.

Demo:

https://github.com/user-attachments/assets/79ea9066-e539-4fbb-87b2-82a7bdcd726b


